### PR TITLE
more flexible port schema, add analog directions

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -50,14 +50,38 @@ const busInterfaces = {
   }
 };
 
+const wire = {
+  oneOf: [{
+    type: 'integer'
+  }, {
+    type: 'string'
+  }, {
+    type: 'object',
+    required: ['direction', 'width'],
+    properties: {
+      direction: { enum: ['in', 'out', 'analog in', 'analog out', 'analog inout'] },
+      width: {
+        oneOf: [
+          {
+            type: 'integer',
+            minimum: 1
+            // maximum: 65536 // FIXME unbound wire width
+          },
+          {
+            type: 'string'
+          }
+        ]
+      }
+    }
+  }]
+};
+
 const ports = {
   oneOf: [{
     // Main port format:  "pin_name": width +- direction
     type: 'object',
     patternProperties: {
-      '.+': {
-        type: 'integer'
-      }
+      '.+': wire
     }
   }, {
     // Elaborate port format
@@ -67,25 +91,7 @@ const ports = {
       required: ['name', 'wire'],
       properties: {
         name,
-        wire: {
-          type: 'object',
-          required: ['direction', 'width'],
-          properties: {
-            direction: { enum: ['in', 'out', 'analog in', 'analog out', 'analog inout'] },
-            width: {
-              oneOf: [
-                {
-                  type: 'integer',
-                  minimum: 1
-                  // maximum: 65536 // FIXME unbound wire width
-                },
-                {
-                  type: 'string'
-                }
-              ]
-            }
-          }
-        }
+        wire: wire
       }
     }
   }]

--- a/lib/component.js
+++ b/lib/component.js
@@ -71,7 +71,7 @@ const ports = {
           type: 'object',
           required: ['direction', 'width'],
           properties: {
-            direction: { enum: ['in', 'out'] },
+            direction: { enum: ['in', 'out', 'analog in', 'analog out', 'analog inout'] },
             width: {
               oneOf: [
                 {


### PR DESCRIPTION
- allow mixing abbreviated and verbose port descriptions in `ports` definition
- add `analog in`, `analog out`, and `analog inout` wire directions