### PR TITLE
add optional analog field to port wire descriptions

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -59,7 +59,7 @@ const wire = {
     type: 'object',
     required: ['direction', 'width'],
     properties: {
-      direction: { enum: ['in', 'out', 'analog in', 'analog out', 'analog inout'] },
+      direction: { enum: ['in', 'out', 'inout'] },
       width: {
         oneOf: [
           {
@@ -71,7 +71,8 @@ const wire = {
             type: 'string'
           }
         ]
-      }
+      },
+      analog: { enum: ['in', 'out', 'inout'] }
     }
   }]
 };


### PR DESCRIPTION
This replaces the `analog in`, `analog out`, `analog inout` directions with an optional `analog` field that has value `in`, `out`, or `inout`. This allows the `direction` field to exactly match the verilog IP being described while allowing the author to add extra information to indicate what ports are analog signals and what their actual direction is.