### PR TITLE
Update schema format

### DIFF
--- a/lib/busInterface.js
+++ b/lib/busInterface.js
@@ -44,7 +44,7 @@ module.exports = {
             oneOf: [{
               type: 'object',
               patternProperties: {
-                '.+': {'$ref': 'defs#/bundle'}
+                '.+': {'$ref': '#/$defs/bundle'}
               }
             }, {
               type: 'array',

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -9,15 +9,15 @@ module.exports = {
       properties: {
         components: {
           type: 'array',
-          items: {$ref: 'defs#/component'}
+          items: {$ref: '#/$defs/component'}
         },
         designs: {
           type: 'array',
-          items: {$ref: 'defs#/design'}
+          items: {$ref: '#/$defs/design'}
         },
         busDefinitions: {
           type: 'array',
-          items: {$ref: 'defs#/abstractionDefinition'}
+          items: {$ref: '#/$defs/abstractionDefinition'}
         }
       }
     }

--- a/lib/component.js
+++ b/lib/component.js
@@ -70,7 +70,7 @@ const component = {
     busInterfaces: {
       type: 'array',
       uniqueItemProperties: ['name'],
-      items: {$ref: 'defs#/busInterface'}
+      items: {$ref: '#/$defs/busInterface'}
     },
     model: {
       type: 'object',
@@ -96,7 +96,7 @@ const component = {
     memoryMaps: {
       type: 'array',
       uniqueItemProperties: ['name'],
-      items: {$ref: 'defs#/memoryMap'}
+      items: {$ref: '#/$defs/memoryMap'}
     },
     componentGenerators: { type: 'array' },
     fileSets: {

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -56,7 +56,6 @@ const bundle = {
 };
 
 module.exports = {
-  '$id': 'defs',
   catalog,
   component,
   design,

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,4 +20,4 @@ exports.any = {
 };
 exports.component = component;
 exports.abstractionDefinition = abstractionDefinition;
-exports.defs = defs;
+exports.$defs = defs;

--- a/lib/memoryMap.js
+++ b/lib/memoryMap.js
@@ -31,7 +31,7 @@ module.exports = {
           registers: {
             type: 'array',
             uniqueItemProperties: ['name'],
-            items: {$ref: 'defs#/register'}
+            items: {$ref: '#/$defs/register'}
           },
           registerFiles: {
             type: 'array',

--- a/lib/registerFile.js
+++ b/lib/registerFile.js
@@ -17,7 +17,7 @@ const registerFile = {
     registers: {
       type: 'array',
       uniqueItemProperties: ['name'],
-      items: {$ref: 'defs#/register'}
+      items: {$ref: '#/$defs/register'}
     }
     // Handle recursive definitions
     // registerFiles: {


### PR DESCRIPTION
Needed this change in the output schema for
https://github.com/koxudaxi/datamodel-code-generator/

I'm not familiar with the JSON schema format, but maybe there has been changes since this was written?  This allows me to generate a pydantic model corresponding to the schema.  I was just guessing based on the code example here: https://docs.pydantic.dev/latest/concepts/json_schema/#generating-json-schema